### PR TITLE
docs: add complete repository documentation suite and bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,75 @@
+name: "🐛 Bug Report"
+description: Report a reproducible issue with clear details
+title: "[Bug]: "
+labels:
+  - bug
+  - triage
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? Include context and impact.
+      placeholder: Describe the issue clearly.
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: Device type/model where the issue occurred
+      placeholder: e.g., iPhone 14 Pro, MacBook Pro M1
+    validations:
+      required: false
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Browser and version
+      placeholder: e.g., Chrome 126, Safari 17
+    validations:
+      required: false
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a numbered list of steps to reproduce the issue.
+      placeholder: |
+        1. Go to...
+        2. Click on...
+        3. Observe...
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: What should have happened?
+      placeholder: The app should...
+    validations:
+      required: false
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: What actually happened?
+      placeholder: Instead, the app...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this issue?
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# 🤝 Contributing to Ops Intake Copilot
+
+Thanks for your interest in contributing! This project aims to keep bug intake automation simple, reliable, and free for everyone.
+
+## 🚀 How to Contribute
+
+1. Fork the repository.
+2. Create a feature branch from `main`.
+3. Make your changes with clear commit messages.
+4. Test your changes (workflow logic, docs, or templates).
+5. Open a Pull Request with a concise description.
+
+```bash
+git checkout -b feat/your-change-name
+git commit -m "feat: add your change"
+git push origin feat/your-change-name
+```
+
+## 🐞 Reporting Bugs
+
+When opening a bug report, include:
+
+- What happened
+- What you expected
+- Steps to reproduce
+- Environment details (OS, browser, Discord context, n8n version)
+- Logs/screenshots if available
+
+Use the bug issue template whenever possible.
+
+## 💡 Suggesting Enhancements
+
+Enhancement proposals are welcome. Please include:
+
+- Problem statement
+- Proposed solution
+- Alternatives considered
+- Expected impact (maintainability, cost, reliability)
+
+## 🔁 Pull Request Process
+
+- Keep PRs focused and small when possible.
+- Reference related issues in the PR description.
+- Update docs/examples when behavior changes.
+- Ensure no secrets/tokens are committed.
+- Wait for review and address feedback before merge.
+
+### Recommended PR checklist
+
+- [ ] Code or docs updated
+- [ ] Related docs adjusted (`README.md`, `docs/`, `examples/`)
+- [ ] Manual test performed
+- [ ] No sensitive values committed
+
+## 🧹 Code Style Guidelines
+
+- Prefer readable, explicit naming.
+- Keep workflow node names descriptive and stable.
+- Keep prompts deterministic and easy to audit.
+- Use Markdown tables/headings consistently in docs.
+- Avoid unnecessary complexity; optimize for maintainability.
+
+## 🙌 Community Standards
+
+Be respectful and constructive in all interactions. Assume good intent, give actionable feedback, and help keep the project welcoming to contributors of all levels.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Ops Intake Copilot Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,136 +1,188 @@
 # 🤖 Ops Intake Copilot
 
-[![n8n](https://img.shields.io/badge/n8n-v2.9.4-blue)](https://n8n.io)
-[![Groq](https://img.shields.io/badge/Groq-LLaMA%203-green)](https://groq.com)
-[![Discord](https://img.shields.io/badge/Discord-Bot-purple)](https://discord.com)
-[![GitHub](https://img.shields.io/badge/GitHub-Issues-black)](https://github.com)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Cost](https://img.shields.io/badge/Cost-%240-brightgreen)](https://github.com)
+[![n8n](https://img.shields.io/badge/n8n-self--hosted-EA4B71?logo=n8n&logoColor=white)](https://n8n.io)
+[![Groq](https://img.shields.io/badge/Groq-LLaMA_3-FF4F00?logo=groq&logoColor=white)](https://groq.com)
+[![Discord](https://img.shields.io/badge/Discord-Bot-5865F2?logo=discord&logoColor=white)](https://discord.com)
+[![GitHub Issues](https://img.shields.io/badge/GitHub-Issues-181717?logo=github&logoColor=white)](https://github.com/features/issues)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Cost: $0](https://img.shields.io/badge/Cost-%240-success)](#-cost-breakdown)
 
-**Zero-cost automated bug intake from Discord to GitHub Issues using AI**
+> **Zero-cost automated bug intake from Discord to GitHub Issues using Groq AI.**
 
-## 📋 Table of Contents
-- [Features](#-features)
-- [How It Works](#-how-it-works)
-- [Tech Stack](#-tech-stack)
-- [Quick Start](#-quick-start)
-- [Cost Breakdown](#-cost-breakdown)
-- [Examples](#-examples)
-- [Documentation](#-documentation)
-- [License](#-license)
+Ops Intake Copilot captures bug reports from Discord, uses Groq LLaMA 3 to structure and validate details, and creates clean GitHub Issues automatically. It can also detect incomplete reports or non-bug messages and respond accordingly.
+
+---
 
 ## ✨ Features
 
-| Feature | Description |
-|---------|-------------|
-| 🤖 **AI-Powered Extraction** | Uses Groq LLaMA 3 to parse unstructured bug reports |
-| 📋 **Smart Routing** | Detects questions vs. bugs, asks for missing info |
-| 🐙 **GitHub Integration** | Creates formatted issues with labels and templates |
-| 💰 **100% Free** | Only uses generous free tiers from all platforms |
-| 🚀 **Self-Hosted** | Runs on your own n8n instance with Cloudflare tunnel |
-| 🔄 **Real-time** | Instant processing with Discord webhooks |
+| Feature | What It Does | Why It Matters |
+| --- | --- | --- |
+| 🤖 AI extraction | Uses Groq LLaMA 3 to parse free-form messages into structured bug data | Removes manual triage overhead |
+| 📥 Discord-first intake | Lets users submit bugs where they already chat | Faster reporting, less context switching |
+| 🧠 Smart classification | Detects complete report, incomplete report, or question/chat | Prevents noisy issue creation |
+| 🐙 GitHub Issue creation | Auto-creates standardized GitHub Issues with metadata | Improves engineering workflow quality |
+| 🔁 Follow-up prompts | Requests missing details in Discord when data is incomplete | Improves bug completeness before filing |
+| 💸 Zero-cost stack | Built with free tiers/self-hosted tools | Sustainable for indie teams and OSS |
+
+---
 
 ## 🔄 How It Works
 
-```mermaid
-graph LR
-    A[Discord User] -->|Bug Report| B[n8n Trigger Bot]
-    B -->|Webhook| C[n8n Workflow]
-    C -->|AI Analysis| D[Groq LLaMA 3]
-    C -->|Complete Report| E[GitHub Issues]
-    C -->|Missing Info| F[Custom Discord Bot]
-    F -->|Ask for details| A
-    E -->|Issue URL| F
-🛠️ Tech Stack
-Component	Technology	Cost
-Automation Engine	n8n (self-hosted)	$0
-AI Processing	Groq (LLaMA 3)	$0
-Chat Interface	Discord + n8n Trigger Bot	$0
-Issue Tracking	GitHub Issues	$0
-Tunneling	Cloudflare Tunnel	$0
-Response Bot	Custom Discord Bot	$0
-TOTAL		$0
-🚀 Quick Start
-Prerequisites
-n8n self-hosted instance (v2.9.4+)
+1. A user posts a bug report in a Discord channel.
+2. The **n8n Trigger Bot** captures the message and sends it into the workflow.
+3. n8n calls **Groq LLaMA 3** to extract fields (title, device, browser, severity, repro steps, etc.).
+4. The workflow classifies the message:
+   - ✅ Complete bug report → create GitHub Issue.
+   - ⚠️ Incomplete bug report → ask follow-up in Discord.
+   - 💬 Question/greeting → send a helpful response, no issue created.
+5. A response message is posted back to Discord with either:
+   - the created GitHub Issue link, or
+   - a request for missing information.
 
-Cloudflare tunnel (or ngrok)
+---
 
-Discord server with "Manage Server" permissions
+## 🛠️ Tech Stack
 
-GitHub account
+| Layer | Tool | Usage | Cost |
+| --- | --- | --- | --- |
+| Workflow automation | n8n (self-hosted) | Message orchestration + branching logic | $0 |
+| AI extraction | Groq (LLaMA 3) | NLP parsing + bug data extraction | $0 (free tier) |
+| Chat intake | Discord Bots | User submission + bot replies | $0 |
+| Issue tracking | GitHub Issues | Canonical bug backlog | $0 |
+| Public webhook access | Cloudflare Tunnel | Secure ingress to self-hosted n8n | $0 |
 
-5-Minute Setup
-Clone this repository
+---
 
-bash
-git clone https://github.com/yourusername/ops-intake-copilot.git
+## 🚀 Quick Start
+
+### 1) Clone the repository
+
+```bash
+git clone https://github.com/your-username/ops-intake-copilot.git
 cd ops-intake-copilot
-Import the n8n workflow
+```
 
-Open your n8n instance
+### 2) Prepare required credentials
 
-Go to Workflows → Import from File
+Create and store these values securely:
 
-Select workflow/ops-intake-copilot.json
+```bash
+# Required secrets
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxx
+GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxx
+DISCORD_BOT_TOKEN=xxxxxxxxxxxxxxxxx
+```
 
-Set up Discord bots
+### 3) Expose your local n8n instance
 
-Invite n8n Trigger Bot: https://discord.com/discovery/applications/1389933424331980993
+```bash
+# Example: Cloudflare Tunnel
+cloudflared tunnel --url http://localhost:5678
+```
 
-Create Custom Bot (see SETUP.md)
+### 4) Import and configure the workflow in n8n
 
-Configure credentials in n8n
+```bash
+# In n8n UI:
+# Workflows -> Import from File -> select your workflow JSON
+# Then map credentials for GitHub, Groq, and Discord
+```
 
-GitHub Personal Access Token
+### 5) Send a test report in Discord
 
-Groq API Key
+```text
+App crashes when uploading profile photo on iPhone 14 Pro using Safari.
+Steps: Open app -> Profile -> Upload -> Select image.
+Expected: photo uploads.
+Actual: app closes immediately.
+Severity: High.
+```
 
-Discord Bot Token
+If configured correctly, Ops Intake Copilot will create a GitHub Issue and respond with the issue link in Discord.
 
-Activate the workflow
+---
 
-Toggle the workflow to Active
+## 💰 Cost Breakdown
 
-Test with: App crashes on iPhone with Safari
+| Service | Plan | Typical Usage in This Project | Monthly Cost |
+| --- | --- | --- | --- |
+| n8n | Self-hosted | Unlimited local workflow runs | $0 |
+| Groq | Free tier | LLaMA 3 API calls for parsing | $0 |
+| Discord | Free | Bot messaging + channel events | $0 |
+| GitHub | Free | Issue management | $0 |
+| Cloudflare Tunnel | Free | Public endpoint to local n8n | $0 |
+| **Total** |  |  | **$0** |
 
-📚 For detailed instructions, see SETUP.md
+---
 
-💰 Cost Breakdown
-Service	Tier Used	Limits	Cost
-n8n	Self-hosted	Unlimited	$0
-Cloudflare	Free	Unlimited tunnels	$0
-Discord	Free	Unlimited messages	$0
-Groq	Free	500K tokens/minute	$0
-GitHub	Free	Unlimited repos	$0
-Monthly Total			$0
-📝 Examples
-Input: Complete Bug Report
-text
-App crashes when I try to upload a profile picture. 
-Using iPhone 14 Pro with Safari. 
-Click upload button, app closes immediately. 
-This is critical!
-Output: Discord Response
-text
-🔴 **Bug Report Created!**
+## 🧪 Examples
 
-**Title:** App crashes during upload
-**Device:** iPhone 14 Pro
-**Browser:** Safari
-**Severity:** High
+### 1) Complete report (creates issue)
 
-🔗 **GitHub Issue:** https://github.com/user/repo/issues/42
-📚 Documentation
-Setup Guide - Complete installation instructions
+**Input**
 
-Architecture - System design and data flow
+```text
+The dashboard crashes when I click Export CSV.
+Device: MacBook Pro M1
+Browser: Chrome 126
+Steps: Open dashboard -> click Export CSV
+Expected: file downloads
+Actual: blank page with 500 error
+Severity: High
+```
 
-Troubleshooting - Common issues and solutions
+**Behavior**
 
-Examples - Test messages and sample outputs
+- Classified as `complete_bug_report`
+- GitHub Issue created
+- Discord reply includes issue URL
 
-📄 License
-This project is licensed under the MIT License - see the LICENSE file.
+### 2) Incomplete report (asks follow-up)
 
-<p align="center"> Built with ❤️ for the developer community <br> <a href="https://github.com/yourusername/ops-intake-copilot">⭐ Star on GitHub</a> </p> ```
+**Input**
+
+```text
+Login is broken.
+```
+
+**Behavior**
+
+- Classified as `incomplete_bug_report`
+- Bot asks for missing details (device, browser, steps, expected vs actual)
+- No issue created yet
+
+### 3) Question / general message (no issue)
+
+**Input**
+
+```text
+Hey bot, what kind of reports can I send here?
+```
+
+**Behavior**
+
+- Classified as `question_or_chat`
+- Bot responds with guidance/examples
+- No issue created
+
+---
+
+## 📚 Documentation
+
+- [Setup Guide](docs/SETUP.md) — full installation and credential configuration
+- [Troubleshooting](docs/TROUBLESHOOTING.md) — common problems and fixes
+- [Test Messages](examples/test-messages.txt) — ready-to-send message scenarios
+- [Sample Issue](examples/sample-issue.md) — example GitHub issue output
+
+---
+
+## 📄 License
+
+This project is licensed under the [MIT License](LICENSE).
+
+---
+
+<p align="center">
+  Built with 🚀 using n8n + Groq + Discord + GitHub<br />
+  If this helped you, consider giving the repo a ⭐
+</p>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,214 @@
+# ⚙️ Ops Intake Copilot Setup Guide
+
+This guide walks you through a full setup of Ops Intake Copilot with:
+
+- n8n (self-hosted)
+- Groq API
+- Discord bots
+- GitHub Issues
+- Cloudflare Tunnel
+
+---
+
+## ✅ Prerequisites
+
+Before starting, make sure you have:
+
+- A running self-hosted **n8n** instance
+- A **GitHub** account with access to target repository issues
+- A **Groq** account for API access
+- A **Discord** server with permission to add/manage bots
+- **Cloudflare Tunnel** installed (or similar public tunnel)
+
+Optional but recommended:
+
+- A dedicated Discord channel like `#bug-reports`
+- A separate GitHub label set (e.g., `bug`, `triage`, `discord-intake`)
+
+---
+
+## 1) Create GitHub Token (Issues Write Access)
+
+1. Go to GitHub: **Settings → Developer Settings → Personal access tokens**.
+2. Choose either:
+   - Fine-grained token (recommended), or
+   - Classic token (`repo` scope).
+3. Grant access to the target repository.
+4. Ensure permissions include **Issues: Read and write**.
+5. Copy token and store it securely.
+
+Example secret storage:
+
+```bash
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxx
+```
+
+---
+
+## 2) Create Groq API Key
+
+1. Sign in to [Groq Console](https://console.groq.com/).
+2. Open **API Keys**.
+3. Create a new key.
+4. Copy and securely store the key.
+
+```bash
+export GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxx
+```
+
+---
+
+## 3) Create Discord Bots
+
+You need **two bot roles** in this architecture:
+
+- **A. n8n Trigger Bot** (receives channel events/messages)
+- **B. Custom Bot** (posts friendly responses/requests for details)
+
+> You can implement both behaviors with one bot token if your workflow supports it, but separating responsibilities is cleaner for maintenance.
+
+### A) n8n Trigger Bot Setup
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications).
+2. Create a new application (e.g., `Ops Intake Trigger`).
+3. In **Bot** tab, create bot and copy token.
+4. Enable intents needed for your workflow:
+   - `MESSAGE CONTENT INTENT`
+   - `SERVER MEMBERS INTENT` (only if required)
+5. Under OAuth2 URL Generator:
+   - Scopes: `bot`
+   - Bot permissions: `Read Messages/View Channels`, `Send Messages`, `Read Message History`
+6. Invite bot to your server.
+
+```bash
+export DISCORD_TRIGGER_BOT_TOKEN=xxxxxxxxxxxxxxxxxxxxx
+```
+
+### B) Custom Response Bot Setup
+
+1. Create a second Discord application (e.g., `Ops Intake Responder`).
+2. Create bot and copy token.
+3. Grant permissions:
+   - `Send Messages`
+   - `Embed Links`
+   - `Read Message History`
+4. Invite to same server/channel.
+
+```bash
+export DISCORD_RESPONSE_BOT_TOKEN=xxxxxxxxxxxxxxxxxxxxx
+```
+
+---
+
+## 4) Configure n8n Credentials
+
+In n8n UI, create credentials for:
+
+- **GitHub API** credential
+  - Token: `GITHUB_TOKEN`
+- **HTTP Header Auth** or generic API credential for Groq
+  - Header: `Authorization: Bearer <GROQ_API_KEY>`
+- **Discord credentials**
+  - Trigger bot token
+  - Response bot token (if separate)
+
+Recommended environment variables for n8n deployment:
+
+```bash
+N8N_HOST=localhost
+N8N_PORT=5678
+N8N_PROTOCOL=http
+WEBHOOK_URL=https://your-public-url.example.com/
+```
+
+---
+
+## 5) Configure Cloudflare Tunnel (Webhook Access)
+
+If n8n is local/private, expose it publicly so Discord webhooks can reach it.
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create ops-intake-copilot
+cloudflared tunnel --url http://localhost:5678
+```
+
+Copy the generated HTTPS URL and set it in n8n as `WEBHOOK_URL`.
+
+---
+
+## 6) Import and Configure n8n Workflow
+
+1. Open n8n.
+2. Go to **Workflows → Import from File**.
+3. Import your Ops Intake Copilot workflow JSON.
+4. Open each node and map credentials:
+   - Discord Trigger
+   - Groq API request
+   - Classification logic (complete/incomplete/question)
+   - GitHub Issue creation
+   - Discord response node
+5. Save and activate workflow.
+
+---
+
+## 7) Webhook Configuration Checklist
+
+- n8n workflow is **Active**.
+- Webhook URL is public and HTTPS.
+- Discord bot has channel access.
+- Bot intents include message content.
+- GitHub token can write issues.
+- Groq key is valid and not rate-limited.
+
+---
+
+## 8) Testing Instructions
+
+### Test A: Complete bug report
+
+Send in Discord:
+
+```text
+Search page crashes after pressing Enter.
+Device: Pixel 7
+Browser: Chrome 125
+Steps: Open search -> type term -> press Enter
+Expected: results page loads
+Actual: app freezes and reloads
+Severity: High
+```
+
+Expected result:
+
+- Workflow classifies as complete.
+- GitHub Issue is created.
+- Discord reply includes issue URL.
+
+### Test B: Incomplete report
+
+```text
+Export does not work.
+```
+
+Expected result:
+
+- Workflow asks for missing details.
+- No issue created yet.
+
+### Test C: Question/greeting
+
+```text
+Hi bot, how do I file a good bug report?
+```
+
+Expected result:
+
+- Workflow sends guidance response.
+- No issue created.
+
+---
+
+## ✅ Setup Complete
+
+Once these tests pass, your Ops Intake Copilot is live and ready to triage bug reports automatically from Discord to GitHub.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,177 @@
+# 🛠️ Troubleshooting Guide
+
+Use this guide to quickly diagnose and fix common Ops Intake Copilot issues.
+
+---
+
+## 🤖 Bot Not Responding
+
+### Symptoms
+
+- No reply in Discord after posting a message.
+- n8n workflow does not trigger.
+
+### Checks
+
+1. Verify workflow is **Active** in n8n.
+2. Confirm bot is online in Discord member list.
+3. Ensure bot has channel permissions:
+   - View channel
+   - Read message history
+   - Send messages
+4. Confirm `MESSAGE CONTENT INTENT` is enabled in Discord Developer Portal.
+5. Check n8n execution logs for trigger errors.
+
+### Fixes
+
+- Re-invite bot with correct OAuth scopes/permissions.
+- Re-save credentials in n8n.
+- Restart n8n and bot service if self-hosted.
+
+---
+
+## 🔁 Bot Reading Its Own Messages (Loop)
+
+### Symptoms
+
+- Bot repeatedly responds to itself.
+- Rapid duplicate replies/issues.
+
+### Checks
+
+1. Verify filter logic ignores messages where `author.bot == true`.
+2. Confirm responder bot and trigger bot are handled separately.
+3. Ensure webhook node only handles user messages.
+
+### Fixes
+
+- Add early guard clause in workflow:
+
+```json
+{
+  "if": "message.author.bot === true",
+  "action": "stop"
+}
+```
+
+- Use a dedicated intake channel where only humans post bug reports.
+
+---
+
+## 🐙 GitHub Issues Not Creating
+
+### Symptoms
+
+- Discord says issue creation failed.
+- n8n run reaches GitHub node with error.
+
+### Checks
+
+1. Validate GitHub token is not expired/revoked.
+2. Confirm token has **Issues write** permissions.
+3. Verify repository owner/name is correct.
+4. Check repository allows issues.
+
+### Fixes
+
+- Regenerate token and update n8n credential.
+- Test token manually using API:
+
+```bash
+curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
+```
+
+- Confirm issue creation endpoint payload fields are valid.
+
+---
+
+## 🧠 AI Not Extracting Properly
+
+### Symptoms
+
+- Missing fields in parsed output.
+- Misclassification of reports.
+
+### Checks
+
+1. Verify Groq API key is valid.
+2. Confirm model name is correct (e.g., LLaMA 3 variant).
+3. Inspect prompt instructions in n8n for deterministic field extraction.
+4. Check malformed JSON parsing in response handling.
+
+### Fixes
+
+- Tighten prompt format with explicit schema output.
+- Add fallback defaults for missing optional fields.
+- Add validation step before GitHub node.
+
+---
+
+## ♻️ Duplicate Issues
+
+### Symptoms
+
+- Same report creates multiple GitHub issues.
+
+### Checks
+
+1. Confirm webhook retries are handled idempotently.
+2. Check if multiple workflows listen to same channel/webhook.
+3. Verify user message ID dedupe logic exists.
+
+### Fixes
+
+- Store processed Discord message IDs (KV/DB/cache).
+- Skip creation when `message_id` already processed.
+- Add delay + lock pattern for high traffic channels.
+
+---
+
+## 🌐 Webhook / Cloudflare Tunnel Issues
+
+### Symptoms
+
+- Discord cannot reach webhook.
+- n8n URL works locally but not externally.
+
+### Checks
+
+1. Confirm tunnel is running.
+2. Verify `WEBHOOK_URL` matches current public URL.
+3. Ensure HTTPS URL is used (not HTTP).
+4. Check Cloudflare tunnel logs for connection errors.
+
+### Fixes
+
+- Restart tunnel:
+
+```bash
+cloudflared tunnel --url http://localhost:5678
+```
+
+- Update n8n webhook base URL and reactivate workflow.
+- Avoid rotating URLs by using named persistent tunnels.
+
+---
+
+## ⚡ Quick Reference
+
+| Problem | Most Likely Cause | Fastest Fix |
+| --- | --- | --- |
+| Bot silent | Missing intents or permissions | Enable intents + re-invite bot |
+| Message loop | Bot messages not filtered | Ignore `author.bot == true` |
+| No GitHub issue | Token/repo permission issue | Regenerate token with issues write |
+| Bad AI extraction | Prompt or parsing mismatch | Enforce strict JSON schema output |
+| Duplicates | No dedupe/idempotency | Track Discord message IDs |
+| Webhook offline | Tunnel/URL mismatch | Restart tunnel + update `WEBHOOK_URL` |
+
+---
+
+If issues persist, collect:
+
+- n8n execution ID
+- Relevant node error output
+- Sample Discord input
+- API response snippets (with secrets redacted)
+
+Then open a bug report with this diagnostic data.

--- a/examples/sample-issue.md
+++ b/examples/sample-issue.md
@@ -1,0 +1,37 @@
+# 🐛 [High] App crashes when uploading profile photo on iPhone Safari
+
+## Description
+The mobile app crashes immediately when attempting to upload a profile photo from the account settings screen.
+
+## Environment
+- **Device:** iPhone 14 Pro
+- **OS:** iOS 17.5
+- **Browser/App Context:** Safari (PWA mode)
+- **App Version:** 1.12.0
+
+## Steps to Reproduce
+1. Open the app and sign in.
+2. Navigate to **Profile**.
+3. Tap **Upload Photo**.
+4. Select an image from camera roll.
+5. Tap **Confirm**.
+
+## Expected Result
+Profile photo uploads successfully and a success message appears.
+
+## Actual Result
+The app closes instantly after tapping **Confirm** and returns to iOS home screen.
+
+## Severity
+**High** — blocks account customization for all iOS Safari users.
+
+## Original Report (Discord)
+> App crashes when I try to upload a profile picture. Using iPhone 14 Pro with Safari. Click upload button, app closes immediately. This is critical.
+
+## Metadata
+- **Source:** Discord (`#bug-reports`)
+- **Reported by:** `@jane_doe`
+- **Message ID:** `1258392019384729102`
+- **Intake Classification:** `complete_bug_report`
+- **AI Model:** `Groq LLaMA 3`
+- **Created by:** `Ops Intake Copilot`

--- a/examples/test-messages.txt
+++ b/examples/test-messages.txt
@@ -1,0 +1,41 @@
+# Ops Intake Copilot Test Messages
+
+## 1) Complete Reports (should create GitHub issue)
+
+1. App crashes when I tap "Save Profile" on iPhone 14 using Safari. Steps: Open profile -> change avatar -> tap save. Expected: profile saves. Actual: app closes. Severity: High.
+2. Checkout button does nothing on Windows 11 + Chrome 126. Steps: Add item to cart -> open cart -> click checkout. Expected: payment page opens. Actual: no action. Severity: Medium.
+3. Login form returns 500 error on Android 13 with Firefox. Steps: Open login -> enter valid credentials -> submit. Expected: dashboard opens. Actual: server error page. Severity: High.
+4. Notifications panel overlaps content on iPad Safari. Steps: Open dashboard -> click bell icon. Expected: dropdown aligns top-right. Actual: panel covers main content. Severity: Low.
+5. CSV export produces empty file on macOS Sonoma + Edge. Steps: Go to reports -> export CSV. Expected: file with rows. Actual: empty CSV. Severity: Medium.
+
+## 2) Incomplete Reports (should ask follow-up)
+
+1. Search is broken again.
+2. The app is super slow today.
+3. Upload failed.
+4. I cannot submit the form.
+5. Dashboard looks wrong.
+
+## 3) Questions / Greetings (should NOT create issue)
+
+1. Hi bot 👋
+2. How do I report a bug correctly?
+3. Can you show me an example bug report?
+4. Is this channel only for bugs?
+5. Thanks for the help!
+
+## 4) Edge Cases
+
+1. @bot ???
+2. 
+3. CRASH CRASH CRASH!!!
+4. Bug maybe fixed now, ignore previous message.
+5. Login crash on Chrome, maybe extension issue, maybe not sure.
+
+## 5) Expected Behavior Summary
+
+- Complete reports: classify as complete, create GitHub issue, return issue URL.
+- Incomplete reports: ask for missing fields (steps, expected/actual, environment, severity).
+- Questions/greetings: provide help text, no issue created.
+- Edge cases: avoid false positives, avoid crashes, request clarification when uncertain.
+- All categories: ignore bot-authored messages and prevent duplicate issue creation from same message ID.


### PR DESCRIPTION
### Motivation

- Provide a complete, copy-paste-ready documentation suite so new users can install and operate the Ops Intake Copilot end-to-end 🚀. 
- Standardize contribution and reporting workflows with a `CONTRIBUTING.md` and a GitHub issue form to improve triage quality 🤖. 
- Surface troubleshooting, examples, and configuration details so self-hosted n8n + Groq + Discord setups are reliable and reproducible 📋.

### Description

- Added a full `README.md` with badges, feature table, architecture flow, quick start steps, cost breakdown, examples, and documentation links. 
- Added `CONTRIBUTING.md`, `LICENSE` (MIT 2024), `docs/SETUP.md`, `docs/TROUBLESHOOTING.md`, `examples/test-messages.txt`, and `examples/sample-issue.md` with detailed instructions and templates. 
- Added a structured GitHub issue form at `.github/ISSUE_TEMPLATE/bug-report.yml` with required fields and a `Severity` dropdown for consistent bug intake 🐛.

### Testing

- Ran `git diff --check` to validate whitespace/syntax issues and found no problems (success). 
- Verified repository state with `git status --short` to confirm the new files are present (clean after adding files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a425a701b8833080f1ccefb9a1607b)